### PR TITLE
FIX: Process last chunk

### DIFF
--- a/clamd.go
+++ b/clamd.go
@@ -381,12 +381,12 @@ func (c *Client) streamCmd(tc *textproto.Conn, cmd protocol.Command, f io.Reader
 	for !eof {
 		buf := make([]byte, ChunkSize)
 		if n, err = f.Read(buf); err != nil {
-			if err == io.EOF {
-				err = nil
-				eof = true
-			} else {
+			if err != io.EOF {
 				return
 			}
+
+			err = nil
+			eof = true
 		}
 		if n > 0 {
 			conn.SetDeadline(time.Now().Add(c.cmdTimeout))

--- a/clamd.go
+++ b/clamd.go
@@ -377,14 +377,16 @@ func (c *Client) streamCmd(tc *textproto.Conn, cmd protocol.Command, f io.Reader
 
 	fmt.Fprintf(tc.W, "n%s\n", cmd)
 	b := make([]byte, 4)
-	for {
+	eof := false
+	for !eof {
 		buf := make([]byte, ChunkSize)
 		if n, err = f.Read(buf); err != nil {
 			if err == io.EOF {
 				err = nil
-				break
+				eof = true
+			} else {
+				return
 			}
-			return
 		}
 		if n > 0 {
 			conn.SetDeadline(time.Now().Add(c.cmdTimeout))

--- a/clamd_test.go
+++ b/clamd_test.go
@@ -438,6 +438,39 @@ func TestMethods(t *testing.T) {
 		t.Errorf("Expected true, got %t", b)
 	}
 
+	t.Run("read with early EOF", func(t *testing.T) {
+		// Most readers only return io.EOF, when nothing has been read. Some readers
+		// however return io.EOF already when data is returned. This case needs to work
+		// as well.
+
+		if f, e = os.Open(tfn); e != nil {
+			t.Fatalf("Expected nil got %q", e)
+		}
+		defer f.Close()
+
+		stat, err := f.Stat()
+		if err != nil {
+			t.Fatalf("Expected nil got %q", e)
+		}
+
+		if result, e = c.ScanReader(ctx, &eofReader{f, stat.Size()}); e != nil {
+			t.Errorf("Expected nil got %q", e)
+		}
+		l = len(result)
+		if l == 0 {
+			t.Errorf("Expected a slice of Response objects:, got %v", result)
+		} else if l > 1 {
+			t.Errorf("Expected a slice of Response 1 object:, got %d", l)
+		} else {
+			mb := result[0]
+			if mb.Filename != "stream" {
+				t.Errorf("Expected %q, got %q", "stream", mb.Filename)
+			}
+			if mb.Signature != "Eicar-Signature" {
+				t.Errorf("Expected %q, got %q", "Eicar-Signature", mb.Signature)
+			}
+		}
+	})
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {
@@ -459,4 +492,18 @@ func copyFile(src, dst string, mode os.FileMode) error {
 		return err
 	}
 	return os.Chmod(dst, mode)
+}
+
+type eofReader struct {
+	source io.Reader
+	size   int64
+}
+
+func (e *eofReader) Read(p []byte) (n int, err error) {
+	n, err = e.source.Read(p)
+	e.size -= int64(n)
+	if e.size <= 0 {
+		err = io.EOF
+	}
+	return
 }

--- a/clamd_test.go
+++ b/clamd_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 )
 
@@ -230,6 +231,10 @@ func TestMethodsErrors(t *testing.T) {
 	}
 	if e.Error() != expected {
 		t.Errorf("Got %q want %q", e, expected)
+	}
+
+	if _, e = c.ScanReader(ctx, iotest.ErrReader(io.ErrUnexpectedEOF)); e != io.ErrUnexpectedEOF {
+		t.Errorf("Expected ErrUnexpectedEOF got %q", e)
 	}
 }
 
@@ -500,7 +505,10 @@ type eofReader struct {
 }
 
 func (e *eofReader) Read(p []byte) (n int, err error) {
-	n, err = e.source.Read(p)
+	if n, err = e.source.Read(p); err != nil {
+		return
+	}
+
 	e.size -= int64(n)
 	if e.size <= 0 {
 		err = io.EOF


### PR DESCRIPTION
Some readers (for example a body from a HTTP request) return EOF when not the whole chunk could be read. In that case, the current implementation ignores this chunk completely.

This PR fixes the behavior by also processing the last chunk (which ended with EOF).